### PR TITLE
Add support for installing pip packages globally on >=Debian 12

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,7 @@
     state: "{{ item.state }}"
     umask: "{{ item.umask }}"
     executable: "{{ item.executable }}"
+    extra_args: "{{ (ansible_distribution == 'Debian' and ansible_distribution_version is version('12', '>=')) | ternary('--break-system-packages', '') }}"
   with_items:
     - "{{ patroni_pip_packages }}"
   when: patroni_install_from_pip


### PR DESCRIPTION
Fix for this issue: https://github.com/Zorlin/ansible-role-patroni/issues/1